### PR TITLE
Clean up build scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,16 @@ jobs:
     name: Build charm
     runs-on: ubuntu-latest
     steps:
+      - name: Fix global gitconfig for confined snap
+        run: |
+          # GH automatically includes the git-lfs plugin and configures it in
+          # /etc/gitconfig.  However, the confinement of the charmcraft snap
+          # means that it can see that this file exists but cannot read it, even
+          # if the file permissions should allow it; this breaks git usage within
+          # the snap. To get around this, we move it from the global gitconfig to
+          # the user's .gitconfig file.
+          cat /etc/gitconfig >> $HOME/.gitconfig
+          sudo rm /etc/gitconfig
       - uses: actions/checkout@v2
       - name: Setup Python 3.8
         uses: actions/setup-python@v2

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,19 @@
 CHANNEL ?= unpublished
+CHARM_BUILD_DIR ?= .
 CHARM := sriov-cni
 
 setup-env:
-	bash script/bootstrap
+	@bash script/bootstrap
 
 charm: setup-env
-	bash script/build
+	@env CHARM=$(CHARM) CHARM_BUILD_DIR=$(CHARM_BUILD_DIR) bash script/build
 
-upload:
+upload: setup-env
 ifndef NAMESPACE
 	$(error NAMESPACE is not set)
 endif
 
-	env CHARM=$(CHARM) NAMESPACE=$(NAMESPACE) CHANNEL=$(CHANNEL) bash script/upload
+	@env CHARM=$(CHARM) NAMESPACE=$(NAMESPACE) CHANNEL=$(CHANNEL) CHARM_BUILD_DIR=$(CHARM_BUILD_DIR) bash script/upload
 
 .phony: charm upload setup-env
 all: charm

--- a/image/build
+++ b/image/build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 rm -rf build.tmp
 mkdir build.tmp

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,10 +1,37 @@
 #!/bin/bash
 
-set -x
+set -e
 
-sudo apt update
-sudo apt install -qyf docker.io make unzip python3-pip
-pip3 install --user charmcraft
-sudo snap install go --classic
-sudo snap install charm --classic
-sudo snap install yq
+export PATH="/snap/bin:$PATH"
+
+if [[ "$(snap whoami)" == "email: -" ]]; then
+    snap="sudo snap"
+else
+    snap="snap"
+fi
+
+echo "Verifying dependencies..."
+if ! (which make && which unzip) > /dev/null; then
+    echo "Updating apt..."
+    sudo apt update -yqq
+fi
+if ! which make > /dev/null; then
+    echo "Installing make..."
+    sudo apt install -qyf make
+fi
+if ! which unzip > /dev/null; then
+    echo "Installing unzip..."
+    sudo apt install -qyf unzip
+fi
+if ! which docker > /dev/null; then
+    echo "Installing docker..."
+    $snap install docker
+fi
+if ! which charmcraft > /dev/null; then
+    echo "Installing charmcraft snap..."
+    $snap install charmcraft --beta
+fi
+if ! which yq > /dev/null; then
+    echo "Installing yq..."
+    $snap install yq
+fi

--- a/script/build
+++ b/script/build
@@ -1,10 +1,15 @@
 #!/bin/bash
-
-set -x
+set -eu
 
 export PATH=/snap/bin:$PATH
 
-cd image/
-./build
-cd ..
-$HOME/.local/bin/charmcraft build
+mkdir -p "$CHARM_BUILD_DIR"
+
+CHARM_SRC="$(realpath .)"
+
+echo "Building image..."
+(cd image/; ./build)
+
+echo "Building $CHARM..."
+(cd "$CHARM_BUILD_DIR" && charmcraft build -f "$CHARM_SRC" 2>&1) | sed -e "s,in ',in '$CHARM_BUILD_DIR/,"
+exit "${PIPESTATUS[0]}"

--- a/script/upload
+++ b/script/upload
@@ -1,26 +1,21 @@
 #!/bin/bash
-
-set -x
+set -eu
 
 export PATH=/snap/bin:$PATH
 
-charm whoami
-RET=$?
-if ((RET > 0)); then
-    echo "Not logged into charmstore"
+if ! charm whoami > /dev/null; then
+    echo "Not logged into charm store" 2>&1
     exit 1
 fi
+URL=$(charm push "$CHARM_BUILD_DIR/$CHARM.charm" "cs:~$NAMESPACE/$CHARM" | yq r - url)
+echo "Uploaded: $URL"
 
-rm -rf temp
-mkdir temp
-cd temp
-unzip ../"$CHARM".charm
-URL=$(charm push . cs:~"$NAMESPACE"/"$CHARM" | yq r - url)
-charm attach cs:~"$NAMESPACE"/"$CHARM" --channel unpublished sriov-cni-image=sriov-cni
+IMAGE_NAME="$CHARM-image"
+IMAGE="$CHARM"
+IMAGE_REV=$(charm attach cs:~"$NAMESPACE"/"$CHARM" --channel unpublished "$IMAGE_NAME=$IMAGE" | tail -n1 | sed -e 's/uploaded revision \([0-9]*\) of.*/\1/')
+echo "Attached: $IMAGE_NAME-$IMAGE_REV"
 
 if [ "$CHANNEL" != unpublished ]; then
-    IMAGE_NAME=$(charm list-resources cs:~"$NAMESPACE"/"$CHARM" --channel unpublished --format yaml | yq r - [0].name)
-    IMAGE_REV=$(charm list-resources cs:~"$NAMESPACE"/"$CHARM" --channel unpublished --format yaml | yq r - [0].revision)
-
     charm release "$URL" --channel "$CHANNEL" --resource "$IMAGE_NAME"-"$IMAGE_REV"
+    echo "Released to: $CHANNEL"
 fi


### PR DESCRIPTION
Now that `charm push` can handle `.charm` files and we cleaned up handling of charmcraft on CI, we can remove some messy code from the build scripts.