### PR TITLE
Remove forcing /snap/bin to front of PATH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Builds sriov-cni charm
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eu
 
-export PATH="/snap/bin:$PATH"
-
 if [[ "$(snap whoami)" == "email: -" ]]; then
     snap="sudo snap"
 else

--- a/script/build
+++ b/script/build
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eu
 
-export PATH=/snap/bin:$PATH
-
 mkdir -p "$CHARM_BUILD_DIR"
 
 CHARM_SRC="$(realpath .)"

--- a/script/upload
+++ b/script/upload
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eu
 
-export PATH=/snap/bin:$PATH
-
 if ! charm whoami > /dev/null; then
     echo "Not logged into charm store" 2>&1
     exit 1


### PR DESCRIPTION
CI needs to use the pip package of charmcraft due to the use of a non-standard HOME dir, and if a dev is using the snap then they should already have it on the PATH.