### PR TITLE
Move image build to proper temp dir

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:20.04
-COPY build.tmp/sriov-cni/build/sriov /opt/cni/bin/sriov
+COPY sriov-cni/build/sriov /opt/cni/bin/sriov
 COPY install-sriov-cni.sh /install-sriov-cni.sh
 ENTRYPOINT ["/install-sriov-cni.sh"]

--- a/image/build
+++ b/image/build
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -eu
 
-rm -rf build.tmp
-mkdir build.tmp
-(cd build.tmp
-  git clone https://github.com/intel/sriov-cni --branch v2.3 --depth 1
-  cd sriov-cni
-  make
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+(
+ cp Dockerfile install-sriov-cni.sh "$tmpdir"
+ cd "$tmpdir"
+ git clone https://github.com/intel/sriov-cni --branch v2.3 --depth 1
+ cd sriov-cni
+ make
+ cd ..
+ DOCKER_BUILDKIT=1 docker build . -t sriov-cni
 )
-DOCKER_BUILDKIT=1 docker build . -t sriov-cni
-rm -rf build.tmp

--- a/image/install-sriov-cni.sh
+++ b/image/install-sriov-cni.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-echo "Copying CNI plugins"
+echo "Copying CNI plugins to host"
 cp -rv /opt/cni/bin/* /dest
 
 echo "Sleeping forever"


### PR DESCRIPTION
Jenkins was running into a strange issue cleaning up the build.tmp directory, so this creates a proper temp dir and does the building in that instead.
