### PR TITLE
Fix sriov-cni image build failure due to golang 1.16

### DIFF
--- a/image/build
+++ b/image/build
@@ -4,11 +4,17 @@ set -eu
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 (
- cp Dockerfile install-sriov-cni.sh "$tmpdir"
- cd "$tmpdir"
- git clone https://github.com/intel/sriov-cni --branch v2.3 --depth 1
- cd sriov-cni
- make
- cd ..
- DOCKER_BUILDKIT=1 docker build . -t sriov-cni
+  cp Dockerfile install-sriov-cni.sh "$tmpdir"
+  cd "$tmpdir"
+  git clone https://github.com/intel/sriov-cni --branch v2.3 --depth 1
+  GROUP_ID=$(id -g)
+  USER_ID=$(id -u)
+  docker run \
+    --rm \
+    -e GOOS=linux \
+    -e GOARCH=amd64 \
+    -v "$tmpdir/sriov-cni:/sriov-cni" \
+    golang:1.15 \
+    /bin/bash -c "cd /sriov-cni && make && chown -R ${USER_ID}:${GROUP_ID} /sriov-cni"
+  DOCKER_BUILDKIT=1 docker build . -t sriov-cni
 )


### PR DESCRIPTION
The image build is failing due changes in the golang 1.16 release. Use the docker golang:1.15 image to build sriov-cni instead.

Before:

```
$ ./build
...
running gofmt...
go: cannot find main module, but found glide.lock in /tmp/tmp.tRZbxZRafG/sriov-cni
        to create a module there, run:
        go mod init
setting GOPATH...
building golint...
go: downloading golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5
go: downloading golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7
go: downloading golang.org/x/tools v0.1.0
running golint...
go: cannot find main module, but found glide.lock in /tmp/tmp.tRZbxZRafG/sriov-cni/.gopath/src/github.com/intel/sriov-cni
        to create a module there, run:
        go mod init
Creating build directory...
go: cannot find main module, but found glide.lock in /tmp/tmp.tRZbxZRafG/sriov-cni/.gopath/src/github.com/intel/sriov-cni
        to create a module there, run:
        cd ../.. && go mod init
make: *** [Makefile:60: /tmp/tmp.tRZbxZRafG/sriov-cni/build/sriov] Error 1
```

After:

```
$ ./build
...
running gofmt...
setting GOPATH...
building golint...
running golint...
Creating build directory...
github.com/intel/sriov-cni/vendor/golang.org/x/sys/unix
net
github.com/intel/sriov-cni/vendor/github.com/safchain/ethtool
github.com/intel/sriov-cni/vendor/github.com/vishvananda/netns
github.com/intel/sriov-cni/vendor/github.com/containernetworking/plugins/pkg/utils/sysctl
github.com/intel/sriov-cni/pkg/utils
github.com/intel/sriov-cni/vendor/github.com/containernetworking/plugins/pkg/ns
github.com/intel/sriov-cni/vendor/github.com/containernetworking/cni/pkg/types
github.com/intel/sriov-cni/vendor/github.com/coreos/go-iptables/iptables
github.com/intel/sriov-cni/vendor/github.com/containernetworking/plugins/pkg/utils/hwaddr
github.com/intel/sriov-cni/vendor/github.com/vishvananda/netlink/nl
github.com/intel/sriov-cni/vendor/github.com/containernetworking/cni/pkg/types/020
github.com/intel/sriov-cni/vendor/github.com/containernetworking/cni/pkg/types/current
github.com/intel/sriov-cni/vendor/github.com/containernetworking/cni/pkg/version
github.com/intel/sriov-cni/vendor/github.com/vishvananda/netlink
github.com/intel/sriov-cni/vendor/github.com/containernetworking/cni/pkg/skel
github.com/intel/sriov-cni/vendor/github.com/containernetworking/cni/pkg/invoke
github.com/intel/sriov-cni/pkg/types
github.com/intel/sriov-cni/vendor/github.com/containernetworking/plugins/pkg/ip
github.com/intel/sriov-cni/pkg/config
github.com/intel/sriov-cni/pkg/sriov
github.com/intel/sriov-cni/vendor/github.com/containernetworking/plugins/pkg/ipam
github.com/intel/sriov-cni/cmd/sriov
Building sriov...
Done!
[+] Building 0.3s (8/8) FINISHED
 => [internal] load .dockerignore                                                                                                 0.0s
 => => transferring context: 2B                                                                                                   0.0s
 => [internal] load build definition from Dockerfile                                                                              0.1s
 => => transferring dockerfile: 194B                                                                                              0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                   0.0s
 => [1/3] FROM docker.io/library/ubuntu:20.04                                                                                     0.0s
 => [internal] load build context                                                                                                 0.2s
 => => transferring context: 4.03MB                                                                                               0.1s
 => CACHED [2/3] COPY sriov-cni/build/sriov /opt/cni/bin/sriov                                                                    0.0s
 => CACHED [3/3] COPY install-sriov-cni.sh /install-sriov-cni.sh                                                                  0.0s
 => exporting to image                                                                                                            0.0s
 => => exporting layers                                                                                                           0.0s
 => => writing image sha256:7eb60369b1b4c1b3ef464eafd23fa7ca359afcce1ba8c63f462754031e49475e                                      0.0s
 => => naming to docker.io/library/sriov-cni                                                                                      0.0s
```