### PR TITLE
Add charmcraft.yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.8'
       - name: Run build
         run: |
-          sudo snap install charmcraft --beta
+          sudo snap install charmcraft --classic
           charmcraft build
           cd image
           ./build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Run build
         run: |
           sudo snap install charmcraft --classic
-          charmcraft build
+          charmcraft pack --destructive-mode
           cd image
           ./build

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is an early proof-of-concept charm for deploying and managing Intel's
 This charm can be built locally using [charmcraft][]
 
 ```
-charmcraft build
+charmcraft pack
 ```
 
 ### Building the resources

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,4 @@
+type: charm
+bases:
+- name: ubuntu
+  channel: "20.04"


### PR DESCRIPTION
Fixes build failures with Charmcraft 1.5.0. `charmcraft.yaml` is required now.