### PR TITLE
Pin ops lib manifest to specific commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/canonical/ops-lib-manifest.git@main
+git+https://github.com/canonical/ops-lib-manifest.git@f411bf1b381d49f950de5a778ab7af7811fa646c


### PR DESCRIPTION
Pins the version of ops lib manifest to the one used by the 1.26/beta charm