### PR TITLE
[LP#1999427] retry install-upgrade hook when ManifestClientError occurs

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,30 @@
+list-versions:
+  description: List Versions supported by this charm
+list-resources:
+  description: List Resources of configured version
+  params:
+    resources:
+      type: string
+      default: ""
+      description: |
+        Space separated list of kubernetes resource types to filter list result
+scrub-resources:
+  description: Remove deployments other than the current one
+  params:
+    resources:
+      type: string
+      default: ""
+      description: |
+        Space separated list of kubernetes resource types to filter scrubbing   
+sync-resources:
+  description: |
+    Add kubernetes resources which should be created by this charm which aren't
+    present within the cluster.
+  params:
+    resources:
+      type: string
+      default: ""
+      description: |
+        Space separated list of kubernetes resource types
+        to use a filter during the sync. This helps limit
+        which missing resources are applied.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ops
-git+https://github.com/canonical/ops-lib-manifest.git@main
+git+https://github.com/canonical/ops-lib-manifest.git@0929a0d1483b927783c75cdc5ebe6694b7f26d88


### PR DESCRIPTION
[LP#1999427](https://bugs.launchpad.net/bugs/1999427)

* adding sync-resource action which was inexplicably missing
* use 1.0.0 version of ops-lib-manifest