### PR TITLE
[LP#2002186] include the control-plane toleration in the daemonsets

### DIFF
--- a/.jujuignore
+++ b/.jujuignore
@@ -1,0 +1,4 @@
+build/
+*.charm
+__pycache__/
+.coverage

--- a/src/manifests.py
+++ b/src/manifests.py
@@ -6,6 +6,7 @@
 import logging
 from typing import Dict
 
+from lightkube.models.core_v1 import Toleration
 from ops.manifests import ConfigRegistry, Manifests, Patch
 
 log = logging.getLogger(__name__)
@@ -22,9 +23,38 @@ class SetCNIPath(Patch):
                     v.hostPath.path = self.manifests.config["cni-bin-dir"]
 
 
+class UpdateDaemonSetTolerations(Patch):
+    """Update sriovdp's to also tolerate a noschedule control-plane."""
+
+    def __call__(self, obj):
+        """Update the DaemonSet object in the manifest."""
+        if not (
+            obj.kind == "DaemonSet" and obj.metadata.name.startswith("kube-sriov-cni")
+        ):
+            return
+
+        current_keys = {
+            toleration.key for toleration in obj.spec.template.spec.tolerations
+        }
+        control_plane_key = "node-role.kubernetes.io/control-plane"
+        if control_plane_key not in current_keys:
+            log.info(f"Adding tolerations to {obj.metadata.name}")
+            obj.spec.template.spec.tolerations += [
+                Toleration(
+                    key=control_plane_key,
+                    operator="Exists",
+                    effect="NoSchedule",
+                )
+            ]
+
+
 class SRIOVCNIManifests(Manifests):
     def __init__(self, charm, charm_config):
-        manipulations = [ConfigRegistry(self), SetCNIPath(self)]
+        manipulations = [
+            ConfigRegistry(self),
+            SetCNIPath(self),
+            UpdateDaemonSetTolerations(self),
+        ]
 
         super().__init__("sriov-cni", charm.model, "upstream/sriov-cni", manipulations)
         self.charm_config = charm_config

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -21,6 +21,7 @@ def lk_client():
 def harness():
     harness = Harness(SRIOVCNICharm)
     try:
+        harness.set_leader(True)
         yield harness
     finally:
         harness.cleanup()

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -8,7 +8,40 @@ from typing import List, Tuple
 
 import pytest
 
-from manifests import SetCNIPath
+from manifests import SetCNIPath, UpdateDaemonSetTolerations
+
+
+def test_update_tolerations(harness):
+    harness.disable_hooks()
+    harness.begin_with_initial_hooks()
+    patch = UpdateDaemonSetTolerations(harness.charm.manifests)
+    toleration = mock.MagicMock()
+    toleration.key = "node-role.kubernetes.io/important"
+    toleration.operator = "Exists"
+    toleration.effect = "NoSchedule"
+
+    obj = mock.MagicMock()
+    obj.kind = "DaemonSet"
+    obj.metadata.name = "kube-sriov-cni-ds-amd64"
+    obj.spec.template.spec.tolerations = [toleration]
+    patch(obj)
+    assert len(obj.spec.template.spec.tolerations) == 2
+    assert any(
+        t.key.endswith("control-plane") for t in obj.spec.template.spec.tolerations
+    )
+    assert any(t.key.endswith("important") for t in obj.spec.template.spec.tolerations)
+
+
+def test_update_tolerations_only_changes_recognized_daemonset(
+    harness,
+):
+    harness.disable_hooks()
+    harness.begin_with_initial_hooks()
+    patch = UpdateDaemonSetTolerations(harness.charm.manifests)
+    obj = mock.Mock(kind="DaemonSet", **{"metadata.name": "not-sriovdp"})
+    patch(obj)
+    # Mock object would raise a TypeError
+    # if any attempt to access the spec is attempted
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -27,9 +27,8 @@ def test_update_tolerations(harness):
     patch(obj)
     assert len(obj.spec.template.spec.tolerations) == 2
     assert any(
-        t.key.endswith("control-plane") for t in obj.spec.template.spec.tolerations
+        t.key.endswith(("control-plane", "important")) for t in obj.spec.template.spec.tolerations
     )
-    assert any(t.key.endswith("important") for t in obj.spec.template.spec.tolerations)
 
 
 def test_update_tolerations_only_changes_recognized_daemonset(

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -26,8 +26,9 @@ def test_update_tolerations(harness):
     obj.spec.template.spec.tolerations = [toleration]
     patch(obj)
     assert len(obj.spec.template.spec.tolerations) == 2
-    assert any(
-        t.key.endswith(("control-plane", "important")) for t in obj.spec.template.spec.tolerations
+    assert all(
+        t.key.endswith(("control-plane", "important"))
+        for t in obj.spec.template.spec.tolerations
     )
 
 


### PR DESCRIPTION
[LP#2002186](https://launchpad.net/bugs/2002186)

only the `master` node toleration is present in the upstream manifest, but that taint isn't used on charmed-kubernetes nodes. 

Update this charm to also tolerate NoSchedule taints on `node-role.kubernetes.io/control-plane`